### PR TITLE
Add support to CoAuthor Plus' guest authors

### DIFF
--- a/src/generators/schema/third-party/coauthor.php
+++ b/src/generators/schema/third-party/coauthor.php
@@ -116,7 +116,7 @@ class CoAuthor extends Author {
 		$data = $this->set_image_from_avatar( $data, $guest_author, $schema_id, $add_hash );
 
 		// If local avatar is present, override.
-		$avatar_meta = \wp_get_attachment_image_src( get_post_thumbnail_id( $guest_author->ID ) );
+		$avatar_meta = \wp_get_attachment_image_src( \get_post_thumbnail_id( $guest_author->ID ) );
 		if ( $avatar_meta ) {
 			$avatar_meta   = [
 				'url'    => $avatar_meta[0],

--- a/src/generators/schema/third-party/coauthor.php
+++ b/src/generators/schema/third-party/coauthor.php
@@ -2,7 +2,9 @@
 
 namespace Yoast\WP\SEO\Generators\Schema\Third_Party;
 
+use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Author;
+
 
 /**
  * Returns schema Author data for the CoAuthor Plus assigned user on a post.
@@ -12,7 +14,7 @@ class CoAuthor extends Author {
 	/**
 	 * The user ID of the author we're generating data for.
 	 *
-	 * @var int
+	 * @var int $user_id
 	 */
 	private $user_id;
 
@@ -63,11 +65,70 @@ class CoAuthor extends Author {
 	}
 
 	/**
+	 * Generate the Person data given a user ID.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return array|bool
+	 */
+	public function generate_from_guest_author( $guest_author ) {
+		$this->user_id = $user_id;
+
+		$data = $this->build_person_data_for_guest_author( $guest_author, true );
+
+		$data['@type'] = 'Person';
+		unset( $data['logo'] );
+
+		// If this is a post and the author archives are enabled, set the author archive url as the author url.
+		// if ( $this->helpers->options->get( 'disable-author' ) !== true ) {
+		// 	$data['url'] = $this->helpers->user->get_the_author_posts_url( $user_id );
+		// }
+
+		return $data;
+
+		//return $this->generate();
+	}
+
+	/**
 	 * Determines a User ID for the Person data.
 	 *
 	 * @return bool|int User ID or false upon return.
 	 */
 	protected function determine_user_id() {
 		return $this->user_id;
+	}
+
+	/**
+	 * Builds our array of Schema Person data for a given user ID.
+	 *
+	 * @param int  $user_id  The user ID to use.
+	 * @param bool $add_hash Wether or not the person's image url hash should be added to the image id.
+	 *
+	 * @return array An array of Schema Person data.
+	 */
+	protected function build_person_data_for_guest_author( $guest_author, $add_hash = false ) {
+		$data      = [
+			'@type' => $this->type,
+			'@id'   => $this->context->site_url . Schema_IDs::PERSON_HASH . \wp_hash( $guest_author->user_login . $guest_author->ID . 'guest' ),
+		];
+
+		$data['name'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->display_name );
+		//$data         = $this->add_image( $data, $guest_author, $add_hash );
+
+		if ( ! empty( $guest_author->description ) ) {
+			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $guest_author->description );
+		}
+
+		//$data = $this->add_same_as_urls( $data, $guest_author, $user_id );
+
+		/**
+		 * Filter: 'wpseo_schema_person_data' - Allows filtering of schema data per user.
+		 *
+		 * @param array $data    The schema data we have for this person.
+		 * @param int   $user_id The current user we're collecting schema data for.
+		 */
+		//$data = \apply_filters( 'wpseo_schema_person_data', $data, $user_id );generate_from_guest_author
+
+		return $data;
 	}
 }

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -74,7 +74,7 @@ class CoAuthors_Plus implements Integration_Interface {
 			return $data;
 		}
 
-		$user = get_queried_object();
+		$user = \get_queried_object();
 
 		if ( empty( $user->type ) || $user->type !== 'guest-author' ) {
 			return $data;

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -183,7 +183,7 @@ class CoAuthors_Plus implements Integration_Interface {
 
 			if ( ! empty( $author_data ) ) {
 				if ( $context->site_represents !== 'person' || $author->ID !== $context->site_user_id ) {
-					$data = array_merge( $data, $authors );
+					$data = \array_merge( $data, $authors );
 				}
 			}
 		}

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -81,7 +81,7 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		// Fix author URL.
-		$author_url                                     = \get_author_posts_url( $user->ID );
+		$author_url                                     = \get_author_posts_url( $user->ID, $user->user_nicename );
 		$graph_piece_generator->context->canonical      = $author_url;
 		$graph_piece_generator->context->main_schema_id = $author_url;
 

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -174,7 +174,7 @@ class CoAuthors_Plus implements Integration_Interface {
 
 		if ( $add_to_graph ) {
 			// Clean all Persons from the schema, as the user stored as post owner might be incorrectly added if the post post has only guest authors as authors.
-			$data = array_filter(
+			$data = \array_filter(
 				$data,
 				function( $piece ) {
 					return empty( $piece['@type'] ) || $piece['@type'] !== 'Person';

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -81,7 +81,7 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		// Fix author URL.
-		$author_url                                     = get_author_posts_url( $user->ID );
+		$author_url                                     = \get_author_posts_url( $user->ID );
 		$graph_piece_generator->context->canonical      = $author_url;
 		$graph_piece_generator->context->main_schema_id = $author_url;
 

--- a/src/integrations/third-party/coauthors-plus.php
+++ b/src/integrations/third-party/coauthors-plus.php
@@ -31,6 +31,7 @@ class CoAuthors_Plus implements Integration_Interface {
 	public function register_hooks() {
 		\add_filter( 'wpseo_schema_graph', [ $this, 'filter_graph' ], 11, 2 );
 		\add_filter( 'wpseo_schema_author', [ $this, 'filter_author_graph' ], 11, 4 );
+		\add_filter( 'wpseo_meta_author', [ $this, 'filter_author_meta' ], 11, 2 );
 	}
 
 	/**
@@ -157,5 +158,30 @@ class CoAuthors_Plus implements Integration_Interface {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Filters the author meta tag
+	 *
+	 * @param string                 $author_name  The article author's display name. Return empty to disable the tag.
+	 * @param Indexable_Presentation $presentation The presentation of an indexable.
+	 * @return string
+	 */
+	public function filter_author_meta( $author_name, $presentation ) {
+		$author_objects = \get_coauthors( $presentation->context->post->id );
+
+		// Fallback in case of error.
+		if ( empty( $author_objects ) ) {
+			return $author_name;
+		}
+
+		$output = '';
+		foreach ( $author_objects as $i => $author ) {
+			$output .= $author->display_name;
+			if ( $i <= ( count( $author_objects ) - 2 ) ) {
+				$output .= ', ';
+			}
+		}
+		return $output;
 	}
 }


### PR DESCRIPTION
Currently, Yoast integration with Co Authors Plus supports displaying multiple authors for a post, but it does not support Guest Authors.

This PR, which is still work in progress, adds support to Guest Authors.

* Test instructions * 

* Enable Yoast and CoAuthors Plus
* Create a post

Now try different authorship states and check the resulting schema:

* only one regular author
* 2 or more authors who are regular users
* mix of regular users and guest authors as authors of the post
* only one guest author as the post author
* multiple guest authors as post authors

Also test guest authors with and without avatars, and with and without emails with gravatars. Check that the image tag is properly added in all cases.

* Known issues * 

This seems to be working fine for `singular` pages, but not working properly for author archives

What other use cases are missing?